### PR TITLE
Remove 'configure forms' limitation

### DIFF
--- a/config/environment-permissions.php
+++ b/config/environment-permissions.php
@@ -13,7 +13,6 @@ return [
         'configure asset containers',
         'configure collections',
         'configure fields',
-        'configure forms',
         'configure globals',
         'configure navs',
         'configure taxonomies',


### PR DESCRIPTION
As long as you don't have permission edit the blueprint itself, the only things you can change here are saved in the database with the eloquent driver.